### PR TITLE
Add CustomScrapeField for explicit scraper methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,12 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-from pydantic_scrapeable_api_model import CacheKey, ScrapeableApiModel, ScrapeableField
+from pydantic_scrapeable_api_model import (
+    CacheKey,
+    ScrapeableApiModel,
+    DetailField,
+    CustomScrapeField,
+)
 
 
 class MyAPI(ScrapeableApiModel):
@@ -29,15 +34,15 @@ class MyAPI(ScrapeableApiModel):
 
     id: CacheKey[int]  # required, unique key (or create a custom `id` property)
     name: str
-    # lazily-scraped field (filled by `scrape_detail` or a custom getter)
-    description: ScrapeableField[str]
+    # lazily-scraped field (filled by `scrape_detail` or a custom method)
+    description: DetailField[str] = CustomScrapeField("fetch_description")
 
     @property
     def detail_endpoint(self) -> str | None:
         return f"/items/{self.id}"
 
     # Optional: fetch a field yourself instead of relying on detail_endpoint
-    async def scrape_description(self) -> None:
+    async def fetch_description(self) -> None:
         resp = await self.request(
             id=f"item-{self.id}-desc",
             url=self._build_url(f"/items/{self.id}/description"),
@@ -49,7 +54,7 @@ class MyAPI(ScrapeableApiModel):
 
 async def main() -> None:
     # Scrape list + detail for all models of MyAPI
-    await MyAPI.scrape_all(check_api=True, use_cache=True)
+    await MyAPI.scrape_list(check_api=True, use_cache=True)
 
     # Work with cached data later
     items = list(MyAPI.load_all_cached())
@@ -59,6 +64,12 @@ async def main() -> None:
 
 asyncio.run(main())
 ```
+
+Fields annotated with `DetailField` begin as placeholders and are populated
+only after `scrape_detail` runs (via `.scrape_list()` by default, `.scrape_detail()`, or a
+custom getter). Pass `scrape_details=False` to `scrape_list` to skip detail scraping. Use
+`CustomScrapeField("method_name")` to register a custom
+method that fills a field during `scrape_detail`.
 
 ### Run All Subclasses
 
@@ -98,7 +109,7 @@ class ExternalFeed(ScrapeableApiModel):
     title: str
 
 # Works because the endpoint is absolute
-asyncio.run(ExternalFeed.scrape_all(check_api=True, use_cache=True))
+asyncio.run(ExternalFeed.scrape_list(check_api=True, use_cache=True, scrape_details=False))
 ```
 
 ### Cached Access Helpers
@@ -147,8 +158,7 @@ class MyWrappedAPI(MyAPI):
 ## API Notes
 
 ```python
-MyModel.scrape_list(check_api=True|False|"/override") -> list[MyModel]
-MyModel.scrape_all(check_api=True, use_cache=True) -> None
+MyModel.scrape_list(check_api=True|False|"/override", use_cache=True|False, scrape_details=True|False) -> list[MyModel]
 MyModel.run(use_cache=True, check_api=True) -> None  # runs all subclasses
 MyModel.get(cache_key=..., check_api=False) -> Optional[MyModel]
 MyModel.load_all_cached() -> Iterable[MyModel]

--- a/README.md
+++ b/README.md
@@ -42,14 +42,15 @@ class MyAPI(ScrapeableApiModel):
         return f"/items/{self.id}"
 
     # Optional: fetch a field yourself instead of relying on detail_endpoint
-    async def fetch_description(self) -> None:
+    async def fetch_description(self) -> str:
         resp = await self.request(
             id=f"item-{self.id}-desc",
             url=self._build_url(f"/items/{self.id}/description"),
             headers={"Accept": "application/json"},
         )
-        if resp:
-            self.description = resp.json()["description"]
+        if not resp:
+            return ""
+        return resp.json()["description"]
 
 
 async def main() -> None:
@@ -68,8 +69,9 @@ asyncio.run(main())
 Fields annotated with `DetailField` begin as placeholders and are populated
 only after `scrape_detail` runs (via `.scrape_list()` by default, `.scrape_detail()`, or a
 custom getter). Pass `scrape_details=False` to `scrape_list` to skip detail scraping. Use
-`CustomScrapeField("method_name")` to register a custom
-method that fills a field during `scrape_detail`.
+`CustomScrapeField("method_name")` to register an async method that returns the
+field's value during `scrape_detail`. These methods are validated to exist and to
+return the same type as the field they populate.
 
 ### Run All Subclasses
 

--- a/demo.py
+++ b/demo.py
@@ -37,7 +37,7 @@ class Post(JSONPlaceholderAPIScraper):
     def detail_endpoint(self) -> str:
         return f"/posts/{self.id}"
 
-    async def fetch_comments_count(self) -> None:
+    async def fetch_comments_count(self) -> int:
         resp = await self.request(
             id=f"post-{self.id}-comments",
             url=self._build_url(f"/posts/{self.id}/comments"),
@@ -45,10 +45,9 @@ class Post(JSONPlaceholderAPIScraper):
         )
         if resp is None:
             # Mark as known-empty to avoid repeated attempts this run
-            self.comments_count = 0
-        else:
-            data: list[dict[str, Any]] = resp.json()
-            self.comments_count = len(data)
+            return 0
+        data: list[dict[str, Any]] = resp.json()
+        return len(data)
 
 
 class Todo(JSONPlaceholderAPIScraper):
@@ -66,9 +65,9 @@ class Todo(JSONPlaceholderAPIScraper):
     def cache_key(self) -> str:
         return str(self.id)
 
-    async def compute_title_length(self) -> None:
+    async def compute_title_length(self) -> int:
         # Demonstrates a non-HTTP field getter
-        self.title_length = len(self.title)
+        return len(self.title)
 
 
 async def main() -> None:

--- a/demo.py
+++ b/demo.py
@@ -6,7 +6,11 @@ from typing import Any
 
 from pydantic_cacheable_model import CacheKey
 
-from pydantic_scrapeable_api_model import ScrapeableApiModel, ScrapeableField
+from pydantic_scrapeable_api_model import (
+    ScrapeableApiModel,
+    DetailField,
+    CustomScrapeField,
+)
 
 
 class JSONPlaceholderAPIScraper(ScrapeableApiModel):
@@ -27,13 +31,13 @@ class Post(JSONPlaceholderAPIScraper):
     userId: int
     title: str
     body: str
-    comments_count: ScrapeableField[int]
+    comments_count: DetailField[int] = CustomScrapeField("fetch_comments_count")
 
     @property
     def detail_endpoint(self) -> str:
         return f"/posts/{self.id}"
 
-    async def scrape_comments_count(self) -> None:
+    async def fetch_comments_count(self) -> None:
         resp = await self.request(
             id=f"post-{self.id}-comments",
             url=self._build_url(f"/posts/{self.id}/comments"),
@@ -56,13 +60,13 @@ class Todo(JSONPlaceholderAPIScraper):
     userId: int
     title: str
     completed: bool
-    title_length: ScrapeableField[int]
+    title_length: DetailField[int] = CustomScrapeField("compute_title_length")
 
     @property
     def cache_key(self) -> str:
         return str(self.id)
 
-    async def scrape_title_length(self) -> None:
+    async def compute_title_length(self) -> None:
         # Demonstrates a non-HTTP field getter
         self.title_length = len(self.title)
 


### PR DESCRIPTION
## Summary
- expose `CustomScrapeField` to map fields to custom scraper methods
- rename `LazyDetailField` to `DetailField` with `UnscrapedDetailFieldType` placeholder
- detail scraping now runs by default in `scrape_list` and `run`

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bde240251c832c937026be28640350